### PR TITLE
fix: put message to sync.pool

### DIFF
--- a/examples/autobahn/server/main.go
+++ b/examples/autobahn/server/main.go
@@ -37,7 +37,7 @@ func (c *WebSocket) OnError(socket *gws.Conn, err error) {
 }
 
 func (c *WebSocket) OnOpen(socket *gws.Conn) {
-	fmt.Println("onopen")
+	fmt.Println("connected")
 }
 
 func (c *WebSocket) OnPing(socket *gws.Conn, payload []byte) {

--- a/examples/autobahn/server/main.go
+++ b/examples/autobahn/server/main.go
@@ -37,19 +37,19 @@ func (c *WebSocket) OnError(socket *gws.Conn, err error) {
 }
 
 func (c *WebSocket) OnOpen(socket *gws.Conn) {
-	println("connected")
+	fmt.Println("onopen")
 }
 
 func (c *WebSocket) OnPing(socket *gws.Conn, payload []byte) {
 	fmt.Printf("onping: payload=%s\n", string(payload))
-	socket.WritePong(payload)
+	_ = socket.WritePong(payload)
 }
 
 func (c *WebSocket) OnPong(socket *gws.Conn, payload []byte) {}
 
 func (c *WebSocket) OnMessage(socket *gws.Conn, message *gws.Message) {
 	defer message.Close()
-	socket.WriteMessage(message.Opcode, message.Bytes())
+	_ = socket.WriteMessage(message.Opcode, message.Bytes())
 }
 
 func cloneBytes(b []byte) []byte {

--- a/examples/client/client.go
+++ b/examples/client/client.go
@@ -47,9 +47,10 @@ func (c *WebSocket) OnOpen(socket *gws.Conn) {
 }
 
 func (c *WebSocket) OnPing(socket *gws.Conn, payload []byte) {
-	socket.WritePong(payload)
+	_ = socket.WritePong(payload)
 }
 
 func (c *WebSocket) OnMessage(socket *gws.Conn, message *gws.Message) {
+	defer message.Close()
 	fmt.Printf("recv: %s\n", message.Data.String())
 }

--- a/examples/echo/main.go
+++ b/examples/echo/main.go
@@ -19,7 +19,7 @@ type Handler struct {
 }
 
 func (c *Handler) OnPing(socket *gws.Conn, payload []byte) {
-	socket.WritePong(payload)
+	_ = socket.WritePong(payload)
 }
 
 func (c *Handler) OnMessage(socket *gws.Conn, message *gws.Message) {

--- a/examples/wss/main.go
+++ b/examples/wss/main.go
@@ -35,7 +35,7 @@ type Websocket struct {
 }
 
 func (c *Websocket) OnPing(socket *gws.Conn, payload []byte) {
-	socket.WritePong(payload)
+	_ = socket.WritePong(payload)
 }
 
 func (c *Websocket) OnMessage(socket *gws.Conn, message *gws.Message) {


### PR DESCRIPTION
## what

after onMeesage(), put message object to sync.pool.

code : `examples/client/client.go`

```go
func (c *WebSocket) OnMessage(socket *gws.Conn, message *gws.Message) {
+	defer message.Close()
	fmt.Printf("recv: %s\n", message.Data.String())
}
```