### PR TITLE
gws.conn 支持关联用户数据

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -87,6 +87,10 @@ type Conn struct {
 	// 压缩拓展配置
 	// Compression extension configuration
 	pd PermessageDeflate
+
+	// 用户数据
+	// User data
+	Userdata any
 }
 
 // ReadLoop


### PR DESCRIPTION
一般每个gws.conn都会有一个对应的用户定义对象，需要在EventHandler 回调中访问。 使用conn中的session map 开销较大，直接支持关联用户自定义对象更灵活。 