### PR TITLE
Optimize WebSocket masking with SIMD and improved scalar path

### DIFF
--- a/internal/mask.go
+++ b/internal/mask.go
@@ -1,0 +1,99 @@
+//go:build !goexperiment.simd
+
+package internal
+
+import "encoding/binary"
+
+// MaskXOR 计算掩码
+// MaskXOR calculates the mask
+func MaskXOR(b []byte, key []byte) {
+	key32 := binary.LittleEndian.Uint32(key)
+	key64 := uint64(key32)<<32 | uint64(key32)
+
+	for len(b) >= 64 {
+		v := binary.LittleEndian.Uint64(b[0:8])
+		binary.LittleEndian.PutUint64(b[0:8], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[8:16])
+		binary.LittleEndian.PutUint64(b[8:16], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[16:24])
+		binary.LittleEndian.PutUint64(b[16:24], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[24:32])
+		binary.LittleEndian.PutUint64(b[24:32], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[32:40])
+		binary.LittleEndian.PutUint64(b[32:40], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[40:48])
+		binary.LittleEndian.PutUint64(b[40:48], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[48:56])
+		binary.LittleEndian.PutUint64(b[48:56], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[56:64])
+		binary.LittleEndian.PutUint64(b[56:64], v^key64)
+
+		b = b[64:]
+	}
+	if len(b) == 0 {
+		return
+	}
+
+	if len(b) >= 32 {
+		v := binary.LittleEndian.Uint64(b[0:8])
+		binary.LittleEndian.PutUint64(b[0:8], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[8:16])
+		binary.LittleEndian.PutUint64(b[8:16], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[16:24])
+		binary.LittleEndian.PutUint64(b[16:24], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[24:32])
+		binary.LittleEndian.PutUint64(b[24:32], v^key64)
+
+		b = b[32:]
+		if len(b) == 0 {
+			return
+		}
+	}
+
+	if len(b) >= 16 {
+		v := binary.LittleEndian.Uint64(b[0:8])
+		binary.LittleEndian.PutUint64(b[0:8], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[8:16])
+		binary.LittleEndian.PutUint64(b[8:16], v^key64)
+
+		b = b[16:]
+		if len(b) == 0 {
+			return
+		}
+	}
+
+	if len(b) >= 8 {
+		v := binary.LittleEndian.Uint64(b[0:8])
+		binary.LittleEndian.PutUint64(b[0:8], v^key64)
+
+		b = b[8:]
+		if len(b) == 0 {
+			return
+		}
+	}
+
+	if len(b) >= 4 {
+		v := binary.LittleEndian.Uint32(b[0:4])
+		binary.LittleEndian.PutUint32(b[0:4], v^key32)
+
+		b = b[4:]
+		if len(b) == 0 {
+			return
+		}
+	}
+
+	for i := range b {
+		b[i] ^= key[i&3]
+	}
+}

--- a/internal/mask_simd.go
+++ b/internal/mask_simd.go
@@ -1,0 +1,380 @@
+//go:build goexperiment.simd
+
+package internal
+
+import (
+	"encoding/binary"
+	"simd/archsimd"
+)
+
+// MaskXOR 计算掩码
+// MaskXOR calculates the mask
+var MaskXOR func(b []byte, key []byte) = MaskXOR_Scalar
+
+func init() {
+	if archsimd.X86.AVX2() {
+		MaskXOR = MaskXOR_SIMD256
+	} else if archsimd.X86.AVX() {
+		MaskXOR = MaskXOR_SIMD128
+	}
+}
+
+// MaskXOR_SIMD128 applies the WebSocket masking key using 128-bit SIMD.
+//
+// Large buffers use vector XOR for better throughput.
+// Small buffers fall back to the scalar path to avoid SIMD setup cost.
+func MaskXOR_SIMD128(b []byte, key []byte) {
+	key32 := binary.LittleEndian.Uint32(key)
+	key64 := uint64(key32)<<32 | uint64(key32)
+
+	// simd initialization is expensive, so we only use it for large buffers
+	if len(b) >= 512 {
+		var key128Bytes [16]byte
+		binary.LittleEndian.PutUint64(key128Bytes[0:8], key64)
+		binary.LittleEndian.PutUint64(key128Bytes[8:16], key64)
+
+		key128 := archsimd.LoadUint8x16(&key128Bytes)
+
+		for len(b) >= 128 {
+			v := archsimd.LoadUint8x16Slice(b[0:16]).Xor(key128)
+			v.StoreSlice(b[0:16])
+
+			v = archsimd.LoadUint8x16Slice(b[16:32]).Xor(key128)
+			v.StoreSlice(b[16:32])
+
+			v = archsimd.LoadUint8x16Slice(b[32:48]).Xor(key128)
+			v.StoreSlice(b[32:48])
+
+			v = archsimd.LoadUint8x16Slice(b[48:64]).Xor(key128)
+			v.StoreSlice(b[48:64])
+
+			v = archsimd.LoadUint8x16Slice(b[64:80]).Xor(key128)
+			v.StoreSlice(b[64:80])
+
+			v = archsimd.LoadUint8x16Slice(b[80:96]).Xor(key128)
+			v.StoreSlice(b[80:96])
+
+			v = archsimd.LoadUint8x16Slice(b[96:112]).Xor(key128)
+			v.StoreSlice(b[96:112])
+
+			v = archsimd.LoadUint8x16Slice(b[112:128]).Xor(key128)
+			v.StoreSlice(b[112:128])
+
+			b = b[128:]
+		}
+		if len(b) == 0 {
+			return
+		}
+	}
+
+	for len(b) >= 64 {
+		v := binary.LittleEndian.Uint64(b[0:8])
+		binary.LittleEndian.PutUint64(b[0:8], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[8:16])
+		binary.LittleEndian.PutUint64(b[8:16], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[16:24])
+		binary.LittleEndian.PutUint64(b[16:24], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[24:32])
+		binary.LittleEndian.PutUint64(b[24:32], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[32:40])
+		binary.LittleEndian.PutUint64(b[32:40], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[40:48])
+		binary.LittleEndian.PutUint64(b[40:48], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[48:56])
+		binary.LittleEndian.PutUint64(b[48:56], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[56:64])
+		binary.LittleEndian.PutUint64(b[56:64], v^key64)
+
+		b = b[64:]
+	}
+	if len(b) == 0 {
+		return
+	}
+
+	if len(b) >= 32 {
+		v := binary.LittleEndian.Uint64(b[0:8])
+		binary.LittleEndian.PutUint64(b[0:8], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[8:16])
+		binary.LittleEndian.PutUint64(b[8:16], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[16:24])
+		binary.LittleEndian.PutUint64(b[16:24], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[24:32])
+		binary.LittleEndian.PutUint64(b[24:32], v^key64)
+
+		b = b[32:]
+		if len(b) == 0 {
+			return
+		}
+	}
+
+	if len(b) >= 16 {
+		v := binary.LittleEndian.Uint64(b[0:8])
+		binary.LittleEndian.PutUint64(b[0:8], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[8:16])
+		binary.LittleEndian.PutUint64(b[8:16], v^key64)
+
+		b = b[16:]
+		if len(b) == 0 {
+			return
+		}
+	}
+
+	if len(b) >= 8 {
+		v := binary.LittleEndian.Uint64(b[0:8])
+		binary.LittleEndian.PutUint64(b[0:8], v^key64)
+
+		b = b[8:]
+		if len(b) == 0 {
+			return
+		}
+	}
+
+	if len(b) >= 4 {
+		v := binary.LittleEndian.Uint32(b[0:4])
+		binary.LittleEndian.PutUint32(b[0:4], v^key32)
+
+		b = b[4:]
+		if len(b) == 0 {
+			return
+		}
+	}
+
+	for i := range b {
+		b[i] ^= key[i&3]
+	}
+}
+
+// MaskXOR_SIMD256 applies the WebSocket masking key using 256-bit AVX2.
+//
+// Large buffers use AVX2 vector XOR for higher throughput.
+// Small buffers fall back to the scalar path.
+func MaskXOR_SIMD256(b []byte, key []byte) {
+	key32 := binary.LittleEndian.Uint32(key)
+	key64 := uint64(key32)<<32 | uint64(key32)
+
+	// simd initialization is expensive, so we only use it for large buffers
+	if len(b) >= 512 {
+		var key256Bytes [32]byte
+		binary.LittleEndian.PutUint64(key256Bytes[0:8], key64)
+		binary.LittleEndian.PutUint64(key256Bytes[8:16], key64)
+		binary.LittleEndian.PutUint64(key256Bytes[16:24], key64)
+		binary.LittleEndian.PutUint64(key256Bytes[24:32], key64)
+
+		key256 := archsimd.LoadUint8x32(&key256Bytes)
+
+		for len(b) >= 128 {
+			v := archsimd.LoadUint8x32Slice(b[0:32]).Xor(key256)
+			v.StoreSlice(b[0:32])
+
+			v = archsimd.LoadUint8x32Slice(b[32:64]).Xor(key256)
+			v.StoreSlice(b[32:64])
+
+			v = archsimd.LoadUint8x32Slice(b[64:96]).Xor(key256)
+			v.StoreSlice(b[64:96])
+
+			v = archsimd.LoadUint8x32Slice(b[96:128]).Xor(key256)
+			v.StoreSlice(b[96:128])
+
+			b = b[128:]
+		}
+
+		// perform VZEROUPPER to avoid AVX-SSE transition penalty on next scalar code
+		// without this the performance can tank drastically on mixed workload.
+		archsimd.ClearAVXUpperBits()
+
+		if len(b) == 0 {
+			return
+		}
+	}
+
+	for len(b) >= 64 {
+		v := binary.LittleEndian.Uint64(b[0:8])
+		binary.LittleEndian.PutUint64(b[0:8], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[8:16])
+		binary.LittleEndian.PutUint64(b[8:16], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[16:24])
+		binary.LittleEndian.PutUint64(b[16:24], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[24:32])
+		binary.LittleEndian.PutUint64(b[24:32], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[32:40])
+		binary.LittleEndian.PutUint64(b[32:40], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[40:48])
+		binary.LittleEndian.PutUint64(b[40:48], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[48:56])
+		binary.LittleEndian.PutUint64(b[48:56], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[56:64])
+		binary.LittleEndian.PutUint64(b[56:64], v^key64)
+
+		b = b[64:]
+	}
+	if len(b) == 0 {
+		return
+	}
+
+	if len(b) >= 32 {
+		v := binary.LittleEndian.Uint64(b[0:8])
+		binary.LittleEndian.PutUint64(b[0:8], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[8:16])
+		binary.LittleEndian.PutUint64(b[8:16], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[16:24])
+		binary.LittleEndian.PutUint64(b[16:24], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[24:32])
+		binary.LittleEndian.PutUint64(b[24:32], v^key64)
+
+		b = b[32:]
+		if len(b) == 0 {
+			return
+		}
+	}
+
+	if len(b) >= 16 {
+		v := binary.LittleEndian.Uint64(b[0:8])
+		binary.LittleEndian.PutUint64(b[0:8], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[8:16])
+		binary.LittleEndian.PutUint64(b[8:16], v^key64)
+
+		b = b[16:]
+		if len(b) == 0 {
+			return
+		}
+	}
+
+	if len(b) >= 8 {
+		v := binary.LittleEndian.Uint64(b[0:8])
+		binary.LittleEndian.PutUint64(b[0:8], v^key64)
+
+		b = b[8:]
+		if len(b) == 0 {
+			return
+		}
+	}
+
+	if len(b) >= 4 {
+		v := binary.LittleEndian.Uint32(b[0:4])
+		binary.LittleEndian.PutUint32(b[0:4], v^key32)
+
+		b = b[4:]
+		if len(b) == 0 {
+			return
+		}
+	}
+
+	for i := range b {
+		b[i] ^= key[i&3]
+	}
+}
+
+// MaskXOR_Scalar applies the WebSocket masking key using scalar operations.
+func MaskXOR_Scalar(b []byte, key []byte) {
+	key32 := binary.LittleEndian.Uint32(key)
+	key64 := uint64(key32)<<32 | uint64(key32)
+
+	for len(b) >= 64 {
+		v := binary.LittleEndian.Uint64(b[0:8])
+		binary.LittleEndian.PutUint64(b[0:8], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[8:16])
+		binary.LittleEndian.PutUint64(b[8:16], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[16:24])
+		binary.LittleEndian.PutUint64(b[16:24], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[24:32])
+		binary.LittleEndian.PutUint64(b[24:32], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[32:40])
+		binary.LittleEndian.PutUint64(b[32:40], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[40:48])
+		binary.LittleEndian.PutUint64(b[40:48], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[48:56])
+		binary.LittleEndian.PutUint64(b[48:56], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[56:64])
+		binary.LittleEndian.PutUint64(b[56:64], v^key64)
+
+		b = b[64:]
+	}
+	if len(b) == 0 {
+		return
+	}
+
+	if len(b) >= 32 {
+		v := binary.LittleEndian.Uint64(b[0:8])
+		binary.LittleEndian.PutUint64(b[0:8], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[8:16])
+		binary.LittleEndian.PutUint64(b[8:16], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[16:24])
+		binary.LittleEndian.PutUint64(b[16:24], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[24:32])
+		binary.LittleEndian.PutUint64(b[24:32], v^key64)
+
+		b = b[32:]
+		if len(b) == 0 {
+			return
+		}
+	}
+
+	if len(b) >= 16 {
+		v := binary.LittleEndian.Uint64(b[0:8])
+		binary.LittleEndian.PutUint64(b[0:8], v^key64)
+
+		v = binary.LittleEndian.Uint64(b[8:16])
+		binary.LittleEndian.PutUint64(b[8:16], v^key64)
+
+		b = b[16:]
+		if len(b) == 0 {
+			return
+		}
+	}
+
+	if len(b) >= 8 {
+		v := binary.LittleEndian.Uint64(b[0:8])
+		binary.LittleEndian.PutUint64(b[0:8], v^key64)
+
+		b = b[8:]
+		if len(b) == 0 {
+			return
+		}
+	}
+
+	if len(b) >= 4 {
+		v := binary.LittleEndian.Uint32(b[0:4])
+		binary.LittleEndian.PutUint32(b[0:4], v^key32)
+
+		b = b[4:]
+		if len(b) == 0 {
+			return
+		}
+	}
+
+	for i := range b {
+		b[i] ^= key[i&3]
+	}
+}

--- a/internal/mask_test.go
+++ b/internal/mask_test.go
@@ -1,0 +1,34 @@
+package internal
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaskByByte(t *testing.T) {
+	var data = []byte("hello")
+	MaskByByte(data, []byte{0xa, 0xb, 0xc, 0xd})
+	assert.Equal(t, "626e606165", hex.EncodeToString(data))
+}
+
+func TestMask(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		var n = AlphabetNumeric.Intn(1024)
+		var s1 = AlphabetNumeric.Generate(n)
+		var s2 = make([]byte, len(s1))
+		copy(s2, s1)
+
+		var key = make([]byte, 4, 4)
+		binary.LittleEndian.PutUint32(key, AlphabetNumeric.Uint32())
+		MaskXOR(s1, key)
+		MaskByByte(s2, key)
+		for i, _ := range s1 {
+			if s1[i] != s2[i] {
+				t.Fail()
+			}
+		}
+	}
+}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"encoding/base64"
-	"encoding/binary"
 	"net"
 	"net/url"
 	"reflect"
@@ -81,44 +80,6 @@ func FnvNumber[T Integer](x T) uint64 {
 	h *= prime64
 	h ^= uint64(x)
 	return h
-}
-
-// MaskXOR 计算掩码
-func MaskXOR(b []byte, key []byte) {
-	var maskKey = binary.LittleEndian.Uint32(key)
-	var key64 = uint64(maskKey)<<32 + uint64(maskKey)
-
-	for len(b) >= 64 {
-		v := binary.LittleEndian.Uint64(b)
-		binary.LittleEndian.PutUint64(b, v^key64)
-		v = binary.LittleEndian.Uint64(b[8:16])
-		binary.LittleEndian.PutUint64(b[8:16], v^key64)
-		v = binary.LittleEndian.Uint64(b[16:24])
-		binary.LittleEndian.PutUint64(b[16:24], v^key64)
-		v = binary.LittleEndian.Uint64(b[24:32])
-		binary.LittleEndian.PutUint64(b[24:32], v^key64)
-		v = binary.LittleEndian.Uint64(b[32:40])
-		binary.LittleEndian.PutUint64(b[32:40], v^key64)
-		v = binary.LittleEndian.Uint64(b[40:48])
-		binary.LittleEndian.PutUint64(b[40:48], v^key64)
-		v = binary.LittleEndian.Uint64(b[48:56])
-		binary.LittleEndian.PutUint64(b[48:56], v^key64)
-		v = binary.LittleEndian.Uint64(b[56:64])
-		binary.LittleEndian.PutUint64(b[56:64], v^key64)
-		b = b[64:]
-	}
-
-	for len(b) >= 8 {
-		v := binary.LittleEndian.Uint64(b[:8])
-		binary.LittleEndian.PutUint64(b[:8], v^key64)
-		b = b[8:]
-	}
-
-	var n = len(b)
-	for i := 0; i < n; i++ {
-		idx := i & 3
-		b[i] ^= key[idx]
-	}
 }
 
 // InCollection 检查给定的字符串 elem 是否在字符串切片 elems 中

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -2,8 +2,6 @@ package internal
 
 import (
 	"bytes"
-	"encoding/binary"
-	"encoding/hex"
 	"hash/fnv"
 	"io"
 	"net/url"
@@ -83,31 +81,6 @@ func TestFNV64(t *testing.T) {
 func TestNewMaskKey(t *testing.T) {
 	var key = NewMaskKey()
 	assert.Equal(t, 4, len(key))
-}
-
-func TestMaskByByte(t *testing.T) {
-	var data = []byte("hello")
-	MaskByByte(data, []byte{0xa, 0xb, 0xc, 0xd})
-	assert.Equal(t, "626e606165", hex.EncodeToString(data))
-}
-
-func TestMask(t *testing.T) {
-	for i := 0; i < 1000; i++ {
-		var n = AlphabetNumeric.Intn(1024)
-		var s1 = AlphabetNumeric.Generate(n)
-		var s2 = make([]byte, len(s1))
-		copy(s2, s1)
-
-		var key = make([]byte, 4, 4)
-		binary.LittleEndian.PutUint32(key, AlphabetNumeric.Uint32())
-		MaskXOR(s1, key)
-		MaskByByte(s2, key)
-		for i, _ := range s1 {
-			if s1[i] != s2[i] {
-				t.Fail()
-			}
-		}
-	}
 }
 
 func TestSplit(t *testing.T) {


### PR DESCRIPTION
## Overview

Optimizes WebSocket masking performance by implementing SIMD acceleration and improvements to the scalar path.

## Changes

* **Split masking implementation**: Created conditional builds with `mask_simd.go` (SIMD-enabled) and `mask.go` (scalar-only)
* **SIMD acceleration**: Added AVX2 and AVX implementations for large buffers (≥512 bytes) with automatic CPU feature detection
* **Smart fallback**: SIMD operations fall back to optimized scalar for smaller buffers to avoid setup overhead
* **Code organization**: Moved masking logic from `utils.go` to dedicated mask files
* **Test reorganization**: Moved mask-specific tests from `utils_test.go` to `mask_test.go`

## SIMD Usage

**SIMD optimizations are automatically enabled when building with:**

```
GOEXPERIMENT=simd
```

At runtime the implementation is selected based on CPU capabilities:

* **AVX2** → 256-bit implementation
* **AVX** → 128-bit implementation
* **otherwise** → optimized scalar fallback

## Performance Benefits

* **Large buffers**: Significant throughput improvement using vectorized XOR operations
* **Small buffers**: Maintains efficiency by avoiding SIMD setup costs
* **Mixed workloads**: Proper AVX state management prevents performance degradation

## Implementation Details

* Runtime CPU feature detection selects optimal implementation
* 128-byte unrolled loops for improved SIMD utilization
* Proper `VZEROUPPER` usage to avoid AVX-SSE transition penalties
* Maintains backward compatibility with existing API

## Benchmarks

Benchmark source and results can be found here: https://github.com/EetuAH/go-ws-mask-simd-bench/tree/main


### In-Place Benchmark (Hot Buffer)

* Small buffers (<64B): The optimized scalar implementation slightly outperforms the original due to reduced loop overhead.
* SIMD128 improves throughput starting at mid-size buffers.
* SIMD256 shows strong scaling once loop overhead amortizes.
* ≥4KB clearly demonstrates AVX2’s 32-byte lane advantage.
* 16KB peaks at ~94 GB/s, entering memory-bound territory.
* Large buffers (256KB) reflect cache/memory bandwidth behavior rather than instruction throughput limits.

<img width="614" height="461" alt="image" src="https://github.com/user-attachments/assets/30d760b2-f438-4aa8-b9a6-2731744d51ac" />

### Copy Benchmark (Streaming / Realistic)

* Small buffers (<64B): The optimized scalar implementation slightly outperforms the original due to reduced loop overhead.
* SIMD128 improves steadily from 512B upward.
* **SIMD256 scales efficiently once loop overhead amortizes.**
* ≥4KB shows clear AVX2 advantage.
* 16KB reaches ~61 GB/s.
* 256KB approaches memory-bandwidth limits.

<img width="614" height="461" alt="image" src="https://github.com/user-attachments/assets/073972c2-ff16-4e02-ad85-586257782f4c" />
