### PR TITLE
Fix authorization panic

### DIFF
--- a/types.go
+++ b/types.go
@@ -57,6 +57,10 @@ var (
 	// Failure to pass forensic authentication
 	ErrUnauthorized = errors.New("gws: unauthorized")
 
+	// ErrNilSession 会话为空
+	// Session is empty
+	ErrNilSession = errors.New("gws: nil session")
+
 	// ErrHandshake 握手错误, 请求头未通过校验
 	// Handshake error, request header does not pass checksum.
 	ErrHandshake = errors.New("gws: handshake error")

--- a/upgrader.go
+++ b/upgrader.go
@@ -186,7 +186,8 @@ func (c *Upgrader) writeErr(conn net.Conn, err error) error {
 // Wraps the authorization function to avoid panic
 func (c *Upgrader) doAuthorize(r *http.Request, session SessionStorage) (result bool) {
 	defer func() {
-		if recover() != nil {
+		if e := recover(); e != nil {
+			c.option.Logger.Error("gws: panic in authorize function: " + e.(string))
 			result = false
 		}
 	}()

--- a/upgrader.go
+++ b/upgrader.go
@@ -183,13 +183,26 @@ func (c *Upgrader) writeErr(conn net.Conn, err error) error {
 	return result
 }
 
+// Wraps the authorization function to avoid panic
+func (c *Upgrader) doAuthorize(r *http.Request, session SessionStorage) (result bool) {
+	defer func() {
+		if recover() != nil {
+			result = false
+		}
+	}()
+
+	result = c.option.Authorize(r, session)
+
+	return
+}
+
 // 从现有的网络连接升级到 WebSocket 连接
 // Upgrades from an existing network connection to a WebSocket connection
 func (c *Upgrader) doUpgradeFromConn(netConn net.Conn, br *bufio.Reader, r *http.Request) (*Conn, error) {
 	// 授权请求，如果授权失败，返回未授权错误
 	// Authorize the request, if authorization fails, return an unauthorized error
 	var session = c.option.NewSession()
-	if !c.option.Authorize(r, session) {
+	if !c.doAuthorize(r, session) {
 		return nil, ErrUnauthorized
 	}
 

--- a/upgrader.go
+++ b/upgrader.go
@@ -199,9 +199,15 @@ func (c *Upgrader) doAuthorize(r *http.Request, session SessionStorage) (result 
 // 从现有的网络连接升级到 WebSocket 连接
 // Upgrades from an existing network connection to a WebSocket connection
 func (c *Upgrader) doUpgradeFromConn(netConn net.Conn, br *bufio.Reader, r *http.Request) (*Conn, error) {
+	// 创建一个新的会话并检查它是否为空
+	// Create a new session and check if it is empty
+	var session = c.option.NewSession()
+	if session == nil {
+		return nil, ErrNilSession
+	}
+
 	// 授权请求，如果授权失败，返回未授权错误
 	// Authorize the request, if authorization fails, return an unauthorized error
-	var session = c.option.NewSession()
 	if !c.doAuthorize(r, session) {
 		return nil, ErrUnauthorized
 	}


### PR DESCRIPTION
If the authorization function causes a panic, the server will crash.

I added doAuthorize function to Upgrader for panics recover.

Also, if the custom function that creates SessionStorage returns nil, other functions that use Session will panic.

