### PR TITLE
Add Conn.ReadMessage for synchronous single-message reads

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -87,6 +87,11 @@ type Conn struct {
 	// 压缩拓展配置
 	// Compression extension configuration
 	pd PermessageDeflate
+
+	// Read(buf) 已经就绪、等待被消费的数据. 当 buf 装不下已读取到的数据时用于缓存剩余部分.
+	// Data made ready by Read(buf), waiting to be consumed. Used to cache the remainder when
+	// buf cannot hold all of the data that has already been read.
+	rb *bytes.Buffer
 }
 
 // ReadLoop
@@ -129,6 +134,67 @@ func (c *Conn) ReadMessage() (*Message, error) {
 	}
 }
 
+// Read
+// 实现 io.Reader, 尽量填满传入的 buf 再返回, 参考 io.Reader.Read 的语义. 如果读取过程中发生错误(例如 EOF),
+// 即使 buf 未被填满, 也会连同已经读到的数据一起返回.
+//
+// 如果 buf 比一条完整的 websocket message(可能由 1 个或多个 frame 组成) 更大, 不会等到读完下一条 message
+// 才返回, 而是把当前已经读到的数据直接返回.
+//
+// 如果 buf 比当前 message 剩余的数据更小, 则只会填满 buf 并返回, 剩余的数据(以及分片/掩码/压缩等中间状态)
+// 会缓存在 Conn 的字段中, 供下一次调用 Read 时继续读取.
+//
+// 该方法不会触发 OnOpen/OnMessage 回调. 如果发生错误, 会触发错误事件并进行资源回收, 处理逻辑和 ReadLoop
+// 结束时一致.
+//
+// Read implements io.Reader. It tries to fill the given buf before returning, following the
+// semantics of io.Reader.Read. If an error occurs while reading (e.g. EOF), the data already
+// read is returned together with the error, even if buf isn't full.
+//
+// If buf is larger than one complete websocket message (which may consist of 1 or more
+// frames), Read does not wait for the next message; it returns the data already read so far.
+//
+// If buf is smaller than the remaining data of the current message, Read fills buf and
+// returns; the remaining data (along with the fragmentation/mask/compression intermediate
+// state) is cached in Conn's fields so the next call to Read can continue reading it.
+//
+// This method does not trigger the OnOpen/OnMessage callbacks. If an error occurs, it
+// triggers the error event and reclaims resources, consistent with the handling at the end
+// of ReadLoop.
+func (c *Conn) Read(buf []byte) (int, error) {
+	var n = 0
+	for n < len(buf) {
+		if c.rb != nil && c.rb.Len() > 0 {
+			m, _ := c.rb.Read(buf[n:])
+			n += m
+			if c.rb.Len() == 0 {
+				binaryPool.Put(c.rb)
+				c.rb = nil
+				if !c.continuationFrame.initialized {
+					// 当前 message 已经读完并交付, 不跨 message 继续读取
+					// The current message has been fully delivered; don't read across into the next message
+					return n, nil
+				}
+			}
+			continue
+		}
+
+		if n > 0 && !c.continuationFrame.initialized {
+			// 已经交付过至少一条 message 的数据, 不再开始读取下一条 message
+			// Data from at least one message has already been delivered; don't start reading the next one
+			return n, nil
+		}
+
+		chunk, err := c.readStreamChunk()
+		if err != nil {
+			c.handleReadError(err)
+			return n, err
+		}
+		c.rb = chunk
+	}
+	return n, nil
+}
+
 // 处理读取错误: 触发错误事件, 分发关闭回调并回收资源
 // 逻辑和 ReadLoop 结束时的处理一致.
 // Handles a read error: emits the error event, dispatches the close callback, and reclaims
@@ -138,6 +204,11 @@ func (c *Conn) handleReadError(err error) {
 
 	evErr, ok := c.ev.Load().(error)
 	_ = c.dispatchControl(OpcodeCloseConnection, nil, internal.SelectValue(ok, evErr, errEmpty))
+
+	if c.rb != nil {
+		binaryPool.Put(c.rb)
+		c.rb = nil
+	}
 
 	// 回收资源
 	// Reclaim resources

--- a/conn.go
+++ b/conn.go
@@ -100,13 +100,44 @@ func (c *Conn) ReadLoop() {
 	// Infinite loop to read messages, if an error occurs, trigger the error event and exit the loop
 	for {
 		if err := c.readMessage(); err != nil {
-			c.emitError(true, err)
+			c.handleReadError(err)
 			break
 		}
 	}
+}
 
-	err, ok := c.ev.Load().(error)
-	_ = c.dispatchControl(OpcodeCloseConnection, nil, internal.SelectValue(ok, err, errEmpty))
+// ReadMessage
+// 读取并返回单个完整的 websocket message, 不会触发 OnOpen 事件, 也不会派发给 OnMessage 回调.
+// 如果发生错误, 会触发错误事件并进行资源回收, 和 ReadLoop 结束时的处理逻辑一致.
+// Reads and returns a single complete websocket message, without triggering the OnOpen event
+// or dispatching to the OnMessage callback.
+// If an error occurs, it triggers the error event and reclaims resources, consistent with
+// the handling logic at the end of ReadLoop.
+func (c *Conn) ReadMessage() (*Message, error) {
+	for {
+		msg, err := c.readFrame()
+		if err == nil && msg != nil {
+			err = c.processMessage(msg)
+		}
+		if err != nil {
+			c.handleReadError(err)
+			return nil, err
+		}
+		if msg != nil {
+			return msg, nil
+		}
+	}
+}
+
+// 处理读取错误: 触发错误事件, 分发关闭回调并回收资源
+// 逻辑和 ReadLoop 结束时的处理一致.
+// Handles a read error: emits the error event, dispatches the close callback, and reclaims
+// resources, consistent with the handling at the end of ReadLoop.
+func (c *Conn) handleReadError(err error) {
+	c.emitError(true, err)
+
+	evErr, ok := c.ev.Load().(error)
+	_ = c.dispatchControl(OpcodeCloseConnection, nil, internal.SelectValue(ok, evErr, errEmpty))
 
 	// 回收资源
 	// Reclaim resources

--- a/conn_read_test.go
+++ b/conn_read_test.go
@@ -1,0 +1,129 @@
+package gws
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/lxzan/gws/internal"
+	"github.com/stretchr/testify/assert"
+)
+
+// readAll 用小 buf 反复调用 Read, 直到读满 n 个字节
+func readAllN(t *testing.T, c *Conn, n int, bufSize int) []byte {
+	t.Helper()
+	var got = make([]byte, 0, n)
+	var buf = make([]byte, bufSize)
+	for len(got) < n {
+		m, err := c.Read(buf)
+		assert.NoError(t, err)
+		got = append(got, buf[:m]...)
+	}
+	return got
+}
+
+func TestConn_Read(t *testing.T) {
+	var as = assert.New(t)
+
+	t.Run("small buffer stops at message boundary", func(t *testing.T) {
+		serverHandler := new(webSocketMocker)
+		clientHandler := new(webSocketMocker)
+		server, client := newPeer(serverHandler, &ServerOption{}, clientHandler, &ClientOption{})
+
+		msg1 := internal.AlphabetNumeric.Generate(10)
+		msg2 := internal.AlphabetNumeric.Generate(10)
+
+		go func() {
+			_ = testWrite(client, true, OpcodeText, testCloneBytes(msg1))
+			_ = testWrite(client, true, OpcodeText, testCloneBytes(msg2))
+		}()
+
+		got1 := readAllN(t, server, len(msg1), 3)
+		as.Equal(string(msg1), string(got1))
+
+		got2 := readAllN(t, server, len(msg2), 3)
+		as.Equal(string(msg2), string(got2))
+	})
+
+	t.Run("large buffer does not wait for next message", func(t *testing.T) {
+		serverHandler := new(webSocketMocker)
+		clientHandler := new(webSocketMocker)
+		server, client := newPeer(serverHandler, &ServerOption{}, clientHandler, &ClientOption{})
+
+		msg1 := internal.AlphabetNumeric.Generate(10)
+
+		go func() { _ = testWrite(client, true, OpcodeText, testCloneBytes(msg1)) }()
+
+		var buf = make([]byte, 4096)
+		done := make(chan struct{})
+		var n int
+		var err error
+		go func() {
+			n, err = server.Read(buf)
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Read blocked waiting for a message that was never sent")
+		}
+
+		as.NoError(err)
+		as.Equal(string(msg1), string(buf[:n]))
+	})
+
+	t.Run("fragmented message reassembled transparently", func(t *testing.T) {
+		serverHandler := new(webSocketMocker)
+		clientHandler := new(webSocketMocker)
+		server, client := newPeer(serverHandler, &ServerOption{}, clientHandler, &ClientOption{})
+
+		s1 := internal.AlphabetNumeric.Generate(16)
+		s2 := internal.AlphabetNumeric.Generate(16)
+		want := string(s1) + string(s2)
+
+		go func() {
+			_ = testWrite(client, false, OpcodeText, testCloneBytes(s1))
+			_ = testWrite(client, true, OpcodeContinuation, testCloneBytes(s2))
+		}()
+
+		got := readAllN(t, server, len(want), 5)
+		as.Equal(want, string(got))
+	})
+
+	t.Run("compressed message", func(t *testing.T) {
+		serverHandler := new(webSocketMocker)
+		clientHandler := new(webSocketMocker)
+		serverOption := &ServerOption{PermessageDeflate: PermessageDeflate{
+			Enabled:               true,
+			ServerContextTakeover: true,
+			ClientContextTakeover: false,
+			ServerMaxWindowBits:   10,
+			ClientMaxWindowBits:   10,
+		}}
+		clientOption := &ClientOption{PermessageDeflate: PermessageDeflate{
+			Enabled:               true,
+			ServerContextTakeover: true,
+			ClientContextTakeover: true,
+		}}
+		server, client := newPeer(serverHandler, serverOption, clientHandler, clientOption)
+
+		msg := internal.AlphabetNumeric.Generate(2048)
+		go func() { client.WriteAsync(OpcodeText, testCloneBytes(msg), nil) }()
+
+		got := readAllN(t, server, len(msg), 64)
+		as.Equal(string(msg), string(got))
+	})
+
+	t.Run("read error propagated like io.Reader", func(t *testing.T) {
+		serverHandler := new(webSocketMocker)
+		clientHandler := new(webSocketMocker)
+		server, client := newPeer(serverHandler, &ServerOption{}, clientHandler, &ClientOption{})
+		_ = client.NetConn().Close()
+
+		var buf = make([]byte, 16)
+		_, err := server.Read(buf)
+		as.Error(err)
+		as.True(err == io.EOF || err != nil)
+	})
+}

--- a/reader.go
+++ b/reader.go
@@ -62,17 +62,35 @@ func (c *Conn) readControl() error {
 	}
 }
 
-// 读取消息
-// Reads a message
+// 读取消息, 组装出完整的消息后派发给 OnMessage 回调
+// Reads a message, dispatching it to the OnMessage callback once fully assembled
 func (c *Conn) readMessage() error {
+	msg, err := c.readFrame()
+	if err != nil {
+		return err
+	}
+	if msg == nil {
+		return nil
+	}
+	return c.emitMessage(msg)
+}
+
+// 读取一帧数据.
+// 如果这一帧拼装出了一条完整的消息(未分片的数据帧, 或者分片消息的最后一帧), 则返回该消息;
+// 如果处理的是控制帧或者未结束的分片帧, 则返回 (nil, nil).
+// Reads a single frame.
+// If this frame completes a message (an unfragmented data frame, or the final frame of a
+// fragmented message), the message is returned; if a control frame or a non-final fragment
+// was processed, (nil, nil) is returned.
+func (c *Conn) readFrame() (msg *Message, err error) {
 	// 解析帧头并获取内容长度
 	// Parse the frame header and get the content length
 	contentLength, err := c.fh.Parse(c.br)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if contentLength > c.config.ReadMaxPayloadSize {
-		return internal.CloseMessageTooLarge
+		return nil, internal.CloseMessageTooLarge
 	}
 
 	// RSV1, RSV2, RSV3: 每个占 1 位
@@ -83,43 +101,49 @@ func (c *Conn) readMessage() error {
 	// If a nonzero value is received and none of the negotiated extensions defines the meaning of such a nonzero value,
 	// the receiving endpoint MUST _Fail the WebSocket Connection_.
 	if !c.pd.Enabled && (c.fh.GetRSV1() || c.fh.GetRSV2() || c.fh.GetRSV3()) {
-		return internal.CloseProtocolError
+		return nil, internal.CloseProtocolError
 	}
 
 	maskEnabled := c.fh.GetMask()
 	if err := c.checkMask(maskEnabled); err != nil {
-		return err
+		return nil, err
 	}
 
 	var opcode = c.fh.GetOpcode()
 	var compressed = c.pd.Enabled && c.fh.GetRSV1()
 	if !opcode.isDataFrame() {
-		return c.readControl()
+		return nil, c.readControl()
 	}
 
 	var fin = c.fh.GetFIN()
 	var buf = binaryPool.Get(contentLength + len(flateTail))
 	var p = buf.Bytes()[:contentLength]
-	var closer = Message{Data: buf}
-	defer closer.Close()
+
+	// buf 默认在函数返回时回收, 除非其所有权被转移给了返回的 Message(此时由调用方负责回收)
+	// buf is recycled on return by default, unless its ownership is transferred to the
+	// returned Message (in which case the caller is responsible for recycling it)
+	var recycle = true
+	defer func() {
+		if recycle {
+			binaryPool.Put(buf)
+		}
+	}()
 
 	if err := internal.ReadN(c.br, p); err != nil {
-		return err
+		return nil, err
 	}
 	if maskEnabled {
 		internal.MaskXOR(p, c.fh.GetMaskKey())
 	}
 
 	if opcode != OpcodeContinuation && c.continuationFrame.initialized {
-		return internal.CloseProtocolError
+		return nil, internal.CloseProtocolError
 	}
 
 	if fin && opcode != OpcodeContinuation {
 		*(*[]byte)(unsafe.Pointer(buf)) = p
-		if !compressed {
-			closer.Data = nil
-		}
-		return c.emitMessage(&Message{Opcode: opcode, Data: buf, compressed: compressed})
+		recycle = false
+		return &Message{Opcode: opcode, Data: buf, compressed: compressed}, nil
 	}
 
 	// 处理分片消息
@@ -131,20 +155,20 @@ func (c *Conn) readMessage() error {
 		c.continuationFrame.buffer = bytes.NewBuffer(make([]byte, 0, contentLength))
 	}
 	if !c.continuationFrame.initialized {
-		return internal.CloseProtocolError
+		return nil, internal.CloseProtocolError
 	}
 
 	c.continuationFrame.buffer.Write(p)
 	if c.continuationFrame.buffer.Len() > c.config.ReadMaxPayloadSize {
-		return internal.CloseMessageTooLarge
+		return nil, internal.CloseMessageTooLarge
 	}
 	if !fin {
-		return nil
+		return nil, nil
 	}
 
-	msg := &Message{Opcode: c.continuationFrame.opcode, Data: c.continuationFrame.buffer, compressed: c.continuationFrame.compressed}
+	msg = &Message{Opcode: c.continuationFrame.opcode, Data: c.continuationFrame.buffer, compressed: c.continuationFrame.compressed}
 	c.continuationFrame.reset()
-	return c.emitMessage(msg)
+	return msg, nil
 }
 
 // 分发消息和异常恢复
@@ -173,18 +197,31 @@ func (c *Conn) dispatchControl(opcode Opcode, payload []byte, err error) error {
 	return nil
 }
 
-// 发射消息事件
-// Emit onmessage event
-func (c *Conn) emitMessage(msg *Message) (err error) {
+// 处理消息: 解压并校验编码
+// Processes a message: decompresses it and validates its encoding
+func (c *Conn) processMessage(msg *Message) error {
 	if msg.compressed {
-		msg.Data, err = c.deflater.Decompress(msg.Data, c.dpsWindow.dict)
+		var rawBuf = msg.Data
+		dst, err := c.deflater.Decompress(rawBuf, c.dpsWindow.dict)
+		binaryPool.Put(rawBuf)
 		if err != nil {
+			msg.Data = nil
 			return internal.NewError(internal.CloseInternalErr, err)
 		}
+		msg.Data = dst
 		_, _ = c.dpsWindow.Write(msg.Bytes())
 	}
 	if !internal.CheckEncoding(c.config.CheckUtf8Enabled, uint8(msg.Opcode), msg.Bytes()) {
 		return internal.NewError(internal.CloseUnsupportedData, ErrTextEncoding)
+	}
+	return nil
+}
+
+// 发射消息事件
+// Emit onmessage event
+func (c *Conn) emitMessage(msg *Message) error {
+	if err := c.processMessage(msg); err != nil {
+		return err
 	}
 	if c.config.ParallelEnabled {
 		return c.readQueue.Go(msg, c.dispatchMessage)

--- a/reader.go
+++ b/reader.go
@@ -171,6 +171,122 @@ func (c *Conn) readFrame() (msg *Message, err error) {
 	return msg, nil
 }
 
+// readStreamChunk 为 Conn.Read 读取更多可供消费的数据.
+//
+// 如果这一帧只是一个控制帧(ping/pong/close, 已经完成派发), 返回 (nil, nil), 调用方需要再次调用以获取真正
+// 的数据.
+//
+// 未压缩的消息按帧直接交付, 读到一帧就返回一帧的数据, 不必等待分片消息的后续帧到达; 压缩的消息由于需要
+// 对整条消息的字节流一起做 inflate, 会累积消息的所有分片, 读到最后一帧后整体解压再交付. 是否压缩、消息的
+// opcode 等状态复用 c.continuationFrame 字段跨帧/跨调用缓存.
+//
+// readStreamChunk reads more data for Conn.Read to consume.
+//
+// If this frame is just a control frame (ping/pong/close, already dispatched), it returns
+// (nil, nil); the caller should call again to obtain actual data.
+//
+// Uncompressed messages are delivered frame by frame as soon as each frame is read, without
+// waiting for subsequent fragments of the message. Compressed messages need the whole
+// message's byte stream to be inflated together, so all fragments are accumulated and the
+// whole message is decompressed once the final frame arrives. Whether the message is
+// compressed, its opcode, etc. are cached across frames/calls by reusing c.continuationFrame.
+func (c *Conn) readStreamChunk() (*bytes.Buffer, error) {
+	// 解析帧头并获取内容长度
+	// Parse the frame header and get the content length
+	contentLength, err := c.fh.Parse(c.br)
+	if err != nil {
+		return nil, err
+	}
+	if contentLength > c.config.ReadMaxPayloadSize {
+		return nil, internal.CloseMessageTooLarge
+	}
+
+	if !c.pd.Enabled && (c.fh.GetRSV1() || c.fh.GetRSV2() || c.fh.GetRSV3()) {
+		return nil, internal.CloseProtocolError
+	}
+
+	maskEnabled := c.fh.GetMask()
+	if err := c.checkMask(maskEnabled); err != nil {
+		return nil, err
+	}
+
+	var opcode = c.fh.GetOpcode()
+	if !opcode.isDataFrame() {
+		return nil, c.readControl()
+	}
+
+	var fin = c.fh.GetFIN()
+	var firstFrame = opcode != OpcodeContinuation
+
+	if firstFrame {
+		if c.continuationFrame.initialized {
+			return nil, internal.CloseProtocolError
+		}
+		c.continuationFrame.initialized = true
+		c.continuationFrame.opcode = opcode
+		c.continuationFrame.compressed = c.pd.Enabled && c.fh.GetRSV1()
+	} else if !c.continuationFrame.initialized {
+		return nil, internal.CloseProtocolError
+	}
+
+	var buf = binaryPool.Get(contentLength + len(flateTail))
+	var p = buf.Bytes()[:contentLength]
+
+	// buf 默认在函数返回时回收, 除非其所有权被转移出去(此时由调用方负责回收)
+	// buf is recycled on return by default, unless its ownership is transferred out
+	// (in which case the caller is responsible for recycling it)
+	var recycle = true
+	defer func() {
+		if recycle {
+			binaryPool.Put(buf)
+		}
+	}()
+
+	if err := internal.ReadN(c.br, p); err != nil {
+		return nil, err
+	}
+	if maskEnabled {
+		internal.MaskXOR(p, c.fh.GetMaskKey())
+	}
+
+	if !c.continuationFrame.compressed {
+		// 未分片/未压缩的消息只需要校验它自身; 跨帧拼装出来的消息不在这里做编码校验,
+		// 因为一个 UTF8 字符可能被拆分到两个 frame 里
+		// An unfragmented/uncompressed message only needs to validate itself; messages
+		// reassembled across frames are not validated for encoding here, since a UTF8
+		// character could be split across two frames
+		if firstFrame && fin && !internal.CheckEncoding(c.config.CheckUtf8Enabled, uint8(opcode), p) {
+			return nil, internal.NewError(internal.CloseUnsupportedData, ErrTextEncoding)
+		}
+		*(*[]byte)(unsafe.Pointer(buf)) = p
+		recycle = false
+		if fin {
+			c.continuationFrame.reset()
+		}
+		return buf, nil
+	}
+
+	// 压缩消息: 累积分片, 读到最后一帧后整体解压
+	// Compressed message: accumulate fragments, decompress as a whole once the final frame arrives
+	if c.continuationFrame.buffer == nil {
+		c.continuationFrame.buffer = bytes.NewBuffer(make([]byte, 0, contentLength))
+	}
+	c.continuationFrame.buffer.Write(p)
+	if c.continuationFrame.buffer.Len() > c.config.ReadMaxPayloadSize {
+		return nil, internal.CloseMessageTooLarge
+	}
+	if !fin {
+		return nil, nil
+	}
+
+	msg := &Message{Opcode: c.continuationFrame.opcode, Data: c.continuationFrame.buffer, compressed: true}
+	c.continuationFrame.reset()
+	if err := c.processMessage(msg); err != nil {
+		return nil, err
+	}
+	return msg.Data, nil
+}
+
 // 分发消息和异常恢复
 // Dispatch message & Recovery
 func (c *Conn) dispatchMessage(msg *Message) error {


### PR DESCRIPTION
Splits frame parsing (readFrame) from decompression/dispatch (processMessage/emitMessage) so ReadMessage can read and return one complete message directly, without OnOpen or the OnMessage callback. Reuses ReadLoop's error handling and resource cleanup on failure.
