### PR TITLE
feat: add callback support to Broadcaster

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -259,6 +259,13 @@ func (c *Broadcaster) writeFrame(socket *Conn, frame *bytes.Buffer) error {
 // 向客户端发送广播消息
 // Send a broadcast message to a client.
 func (c *Broadcaster) Broadcast(socket *Conn) error {
+	return c.BroadcastWithCallback(socket, nil)
+}
+
+// BroadcastWithCallback 广播
+// 向客户端发送广播消息, 并在写入完成后执行回调。
+// Send a broadcast message to a client and invoke callback after the write completes.
+func (c *Broadcaster) BroadcastWithCallback(socket *Conn, callback func(error)) error {
 	var idx = internal.SelectValue(socket.pd.Enabled, 1, 0)
 	var msg = c.msgs[idx]
 
@@ -276,10 +283,16 @@ func (c *Broadcaster) Broadcast(socket *Conn) error {
 
 	atomic.AddInt64(&c.state, 1)
 	socket.writeQueue.Push(func() {
+		defer func() {
+			if atomic.AddInt64(&c.state, -1) == 0 {
+				c.doClose()
+			}
+		}()
+
 		var err = c.writeFrame(socket, msg.frame)
 		socket.emitError(false, err)
-		if atomic.AddInt64(&c.state, -1) == 0 {
-			c.doClose()
+		if callback != nil {
+			callback(err)
 		}
 	})
 	return nil

--- a/writer_test.go
+++ b/writer_test.go
@@ -394,6 +394,58 @@ func TestNewBroadcaster(t *testing.T) {
 	})
 }
 
+func TestBroadcaster_BroadcastWithCallback(t *testing.T) {
+	t.Run("write succeeds", func(t *testing.T) {
+		clientHandler := new(webSocketMocker)
+		server, client := newPeer(new(webSocketMocker), nil, clientHandler, nil)
+		clientHandler.onMessage = func(socket *Conn, message *Message) {
+			message.Close()
+		}
+		t.Cleanup(func() {
+			_ = server.NetConn().Close()
+			_ = client.NetConn().Close()
+		})
+		go client.ReadLoop()
+
+		writeCompleted := make(chan error, 1)
+		payload := []byte("broadcast payload")
+		broadcaster := NewBroadcaster(OpcodeText, payload)
+		assert.NoError(t, broadcaster.BroadcastWithCallback(server, func(err error) {
+			writeCompleted <- err
+		}))
+		broadcaster.Close()
+
+		select {
+		case err := <-writeCompleted:
+			assert.NoError(t, err)
+		case <-time.After(time.Second):
+			t.Fatal("broadcast callback was not invoked")
+		}
+	})
+
+	t.Run("write fails", func(t *testing.T) {
+		server, client := newPeer(new(webSocketMocker), nil, new(webSocketMocker), nil)
+		t.Cleanup(func() {
+			_ = server.NetConn().Close()
+			_ = client.NetConn().Close()
+		})
+		assert.NoError(t, server.NetConn().Close())
+		writeCompleted := make(chan error, 1)
+		broadcaster := NewBroadcaster(OpcodeText, []byte("broadcast payload"))
+
+		assert.NoError(t, broadcaster.BroadcastWithCallback(server, func(err error) {
+			writeCompleted <- err
+		}))
+		broadcaster.Close()
+		select {
+		case err := <-writeCompleted:
+			assert.Error(t, err)
+		case <-time.After(time.Second):
+			t.Fatal("broadcast callback was not invoked")
+		}
+	})
+}
+
 type broadcastHandler struct {
 	BuiltinEventHandler
 	wg      *sync.WaitGroup


### PR DESCRIPTION
Currently, Broadcaster does not support a callback unlike WriteAsync, even though Broadcaster.Broadcast() is also asynchronous. This makes it difficult to write implementations that depend on knowing when the IO is completed. Applications that need this have to rely on using WriteAsync repeatedly which incurs some overhead.

This PR aims to add support for a callback with a new method BroadcastWithCallback(). Appropriate tests have been added and both new and old tests all pass.

Note: Chinese comments were written with the help of translation software to match the repo's bilingual convention. A look would be appreciated.